### PR TITLE
SCP 4628: Marlowe representation of an ACTUS contract

### DIFF
--- a/src/Actus/Core.purs
+++ b/src/Actus/Core.purs
@@ -65,11 +65,11 @@ genProjectedCashflows parties rf ct =
   groupCashflows cf = groupBy f cf
     where
     f (CashFlow a) (CashFlow b) =
-      a.cashEvent == b.cashEvent
-        && a.cashPaymentDay == b.cashPaymentDay
-        && a.cashParty == b.cashParty
-        && a.cashCounterParty == b.cashCounterParty
-        && a.cashCurrency == b.cashCurrency
+      a.event == b.event
+        && a.paymentDay == b.paymentDay
+        && a.party == b.party
+        && a.counterparty == b.counterparty
+        && a.currency == b.currency
 
   netCashflows cf = map (foldl1 plus) $ groupCashflows cf
     where
@@ -126,16 +126,16 @@ genCashflow
   ->
   -- | Projected cash flow
   CashFlow a b
-genCashflow (p1 /\ p2) (ContractTerms { currency }) ((ev /\ { paymentDay, calculationDay }) /\ ContractState { nt } /\ am) =
+genCashflow (party /\ counterparty) (ContractTerms { currency }) ((event /\ { paymentDay, calculationDay }) /\ ContractState { nt } /\ amount) =
   CashFlow
-    { cashParty: p1
-    , cashCounterParty: p2
-    , cashPaymentDay: paymentDay
-    , cashCalculationDay: calculationDay
-    , cashEvent: ev
-    , amount: am
+    { party
+    , counterparty
+    , paymentDay
+    , calculationDay
+    , event
+    , amount
     , notional: nt
-    , cashCurrency: fromMaybe "unknown" currency
+    , currency: fromMaybe "unknown" currency
     }
 
 -- |Generate projected cash flows

--- a/src/Actus/Core.purs
+++ b/src/Actus/Core.purs
@@ -125,8 +125,8 @@ genCashflow
   CashFlow a
 genCashflow (p1 /\ p2) (ContractTerms { currency }) ((ev /\ { paymentDay, calculationDay }) /\ ContractState { nt } /\ am) =
   CashFlow
-    { cashParty: show p1
-    , cashCounterParty: show p2
+    { cashParty: p1
+    , cashCounterParty: p2
     , cashPaymentDay: paymentDay
     , cashCalculationDay: calculationDay
     , cashEvent: ev

--- a/src/Actus/Core.purs
+++ b/src/Actus/Core.purs
@@ -17,8 +17,7 @@ import Data.DateTime (DateTime)
 import Data.Enum (fromEnum)
 import Data.Enum.Generic (class GenericBoundedEnum, genericFromEnum, genericToEnum)
 import Data.Generic.Rep (class Generic)
-import Data.List (List(..), concat, concatMap, dropWhile, filter, filterM, groupBy, mapMaybe, tail, unzip, zip, (..), (:))
-import Data.List as List
+import Data.List (List(..), concat, concatMap, dropWhile, filter, filterM, groupBy, mapMaybe, sortBy, tail, unzip, zip, (..), (:))
 import Data.List.NonEmpty (NonEmptyList, toList)
 import Data.List.NonEmpty as NonEmptyList
 import Data.Maybe (Maybe(..), fromMaybe, isNothing)
@@ -182,7 +181,7 @@ genSchedule
   -- | Schedule
   List Event
 genSchedule contractTerms =
-  List.sortBy (comparing \(ev /\ { paymentDay }) -> (paymentDay /\ ev)) $ genFixedSchedule contractTerms
+  sortBy (comparing \(ev /\ { paymentDay }) -> (paymentDay /\ ev)) $ genFixedSchedule contractTerms
 
 genFixedSchedule
   :: forall a
@@ -196,7 +195,7 @@ genFixedSchedule
   -- | Schedule
   List Event
 genFixedSchedule contractTerms@(ContractTerms { terminationDate, statusDate }) =
-  filter filtersSchedules <<< postProcessSchedules <<< List.sortBy (comparing \(ev /\ { paymentDay }) -> (paymentDay /\ ev)) $ event : concatMap scheduleEvent allElements
+  filter filtersSchedules <<< postProcessSchedules <<< sortBy (comparing \(ev /\ { paymentDay }) -> (paymentDay /\ ev)) $ event : concatMap scheduleEvent allElements
   where
   event :: Event
   event = AD /\ { calculationDay: statusDate, paymentDay: statusDate }
@@ -259,7 +258,7 @@ filtersStates
   -> Reader (CtxSTF a) Boolean
 filtersStates ((event /\ { calculationDay }) /\ _) =
   do
-    contractTerms@(ContractTerms {contractType, purchaseDate, maturityDate, amortizationDate}) <- _.contractTerms <$> ask
+    contractTerms@(ContractTerms { contractType, purchaseDate, maturityDate, amortizationDate }) <- _.contractTerms <$> ask
     pure $ case contractType of
       PAM -> isNothing purchaseDate || Just calculationDay >= purchaseDate
       LAM -> isNothing purchaseDate || event == PRD || Just calculationDay > purchaseDate

--- a/src/Actus/Core.purs
+++ b/src/Actus/Core.purs
@@ -38,7 +38,7 @@ genProjectedCashflows
   => ActusFrac a
   =>
   -- | Risk factors as a function of event type and time
-  (String -> EventType -> DateTime -> RiskFactors a)
+  (EventType -> DateTime -> RiskFactors a)
   ->
   -- | Contract terms
   ContractTerms a
@@ -82,7 +82,7 @@ buildCtx
   => ActusFrac a
   =>
   -- | Risk factors as a function of event type and time
-  (String -> EventType -> DateTime -> RiskFactors a)
+  (EventType -> DateTime -> RiskFactors a)
   ->
   -- | Contract terms
   ContractTerms a

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -182,14 +182,14 @@ data RiskFactors a = RiskFactors
 
 -- | Cash flows
 data CashFlow a b = CashFlow
-  { cashParty :: b
-  , cashCounterParty :: b
-  , cashPaymentDay :: DateTime
-  , cashCalculationDay :: DateTime
-  , cashEvent :: EventType
+  { party :: b
+  , counterparty :: b
+  , paymentDay :: DateTime
+  , calculationDay :: DateTime
+  , event :: EventType
   , amount :: a
   , notional :: a
-  , cashCurrency :: String
+  , currency :: String
   }
 
 derive instance Generic (CashFlow a b) _

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -129,7 +129,8 @@ division lhs rhs =
   let
     n = evalVal lhs
     d = evalVal rhs
-  in Constant' $ division' n d
+  in
+    Constant' $ division' n d
   where
   division' :: BigInt -> BigInt -> BigInt
   division' x _ | x == BigInt.fromInt 0 = BigInt.fromInt 0

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -98,6 +98,29 @@ instance ActusOps Value' where
 instance ActusFrac Value' where
   _ceiling _ = 0 -- FIXME
 
+derive instance Generic Value' _
+derive instance Generic Observation' _
+
+instance Show Value' where
+  show (Constant' i) = "Constant " <> show i
+  show (NegValue' v) = "-" <> show v
+  show (AddValue' a b) = show a <> "+" <> show b
+  show (SubValue' a b) = show a <> "-" <> show b
+  show (MulValue' a b) = show a <> "*" <> show b
+  show (Cond' o a b) = show "if ( " <> show o <> ") then " <> show a <> " else " <> show b
+
+instance Show Observation' where
+  show (AndObs' a b) = "AndObs (" <> show a <> "," <> show b <> ")"
+  show (OrObs' a b) = "OrObs (" <> show a <> "," <> show b <> ")"
+  show (NotObs' a) = "NotObs " <> show a
+  show (ValueGE' a b) = "ValueGE (" <> show a <> "," <> show b <> ")"
+  show (ValueGT' a b) = "ValueGT (" <> show a <> "," <> show b <> ")"
+  show (ValueLT' a b) = "ValueLT (" <> show a <> "," <> show b <> ")"
+  show (ValueLE' a b) = "ValueLE (" <> show a <> "," <> show b <> ")"
+  show (ValueEQ' a b) = "ValueEQ (" <> show a <> "," <> show b <> ")"
+  show TrueObs' = "TrueObs"
+  show FalseObs' = "FalseObs"
+
 marloweFixedPoint :: Int
 marloweFixedPoint = 1000000
 
@@ -155,14 +178,11 @@ data RiskFactors a = RiskFactors
   , o_rf_RRMO :: a
   , o_rf_SCMO :: a
   , pp_payoff :: a
-  , xd_payoff :: a
-  , dv_payoff :: a
   }
 
 -- | Cash flows
 data CashFlow a = CashFlow
-  { tick :: Int
-  , cashParty :: String
+  { cashParty :: String
   , cashCounterParty :: String
   , cashPaymentDay :: DateTime
   , cashCalculationDay :: DateTime

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -25,7 +25,8 @@ import Actus.Domain.ContractState (ContractState(..))
 import Actus.Domain.ContractTerms (BDC(..), CEGE(..), CETC(..), CR(..), CT(..), Calendar(..), ContractTerms(..), Cycle, DCC(..), DS(..), EOMC(..), FEB(..), IPCB(..), OPTP(..), OPXT(..), PPEF(..), PRF(..), PYTP(..), Period(..), SCEF(..), ScheduleConfig, Stub(..))
 import Actus.Domain.Schedule (ShiftedDay, ShiftedSchedule, mkShiftedDay)
 import Control.Alt ((<|>))
-import Data.BigInt.Argonaut (BigInt, abs, fromInt, quot, rem)
+import Data.BigInt.Argonaut (BigInt, abs, quot, rem)
+import Data.BigInt.Argonaut as BigInt
 import Data.DateTime (DateTime)
 import Data.Decimal (Decimal, ceil, fromNumber, toNumber)
 import Data.Decimal as Decimal
@@ -73,9 +74,9 @@ data Observation'
 
 instance Semiring Value' where
   add x y = AddValue' x y
-  mul x y = division (MulValue' x y) (Constant' marloweFixedPoint)
-  one = Constant' marloweFixedPoint
-  zero = Constant' (fromInt 0)
+  mul x y = division (MulValue' x y) (Constant' $ BigInt.fromInt marloweFixedPoint)
+  one = Constant' $ BigInt.fromInt marloweFixedPoint
+  zero = Constant' (BigInt.fromInt 0)
 
 instance Ring Value' where
   sub x y = SubValue' x y
@@ -97,8 +98,8 @@ instance ActusOps Value' where
 instance ActusFrac Value' where
   _ceiling _ = 0 -- FIXME
 
-marloweFixedPoint :: BigInt
-marloweFixedPoint = fromInt 1000000
+marloweFixedPoint :: Int
+marloweFixedPoint = 1000000
 
 division :: Value' -> Value' -> Value'
 division lhs rhs =
@@ -109,20 +110,20 @@ division lhs rhs =
     Constant' (division' n d)
   where
   division' :: BigInt -> BigInt -> BigInt
-  division' x _ | x == fromInt 0 = fromInt 0
-  division' _ y | y == fromInt 0 = fromInt 0
+  division' x _ | x == BigInt.fromInt 0 = BigInt.fromInt 0
+  division' _ y | y == BigInt.fromInt 0 = BigInt.fromInt 0
   division' n d =
     let
       q = n `quot` d
       r = n `rem` d
-      ar = abs r * (fromInt 2)
+      ar = abs r * (BigInt.fromInt 2)
       ad = abs d
     in
       if ar < ad then q -- reminder < 1/2
       else if ar > ad then q + signum n * signum d -- reminder > 1/2
       else
         let -- reminder == 1/2
-          qIsEven = q `rem` (fromInt 2) == (fromInt 0)
+          qIsEven = q `rem` (BigInt.fromInt 2) == (BigInt.fromInt 0)
         in
           if qIsEven then q else q + signum n * signum d
 

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -181,9 +181,9 @@ data RiskFactors a = RiskFactors
   }
 
 -- | Cash flows
-data CashFlow a = CashFlow
-  { cashParty :: String
-  , cashCounterParty :: String
+data CashFlow a b = CashFlow
+  { cashParty :: b
+  , cashCounterParty :: b
   , cashPaymentDay :: DateTime
   , cashCalculationDay :: DateTime
   , cashEvent :: EventType
@@ -192,8 +192,8 @@ data CashFlow a = CashFlow
   , cashCurrency :: String
   }
 
-derive instance Generic (CashFlow a) _
-instance Show a => Show (CashFlow a) where
+derive instance Generic (CashFlow a b) _
+instance (Show a, Show b) => Show (CashFlow a b) where
   show = genericShow
 
 sign :: forall a. Ring a => CR -> a

--- a/src/Actus/Domain.purs
+++ b/src/Actus/Domain.purs
@@ -85,8 +85,8 @@ instance CommutativeRing Value'
 
 instance EuclideanRing Value' where
   degree _ = 1
-  div = division -- different rounding, not using DivValue
-  mod x y = Constant' $ evalVal x `mod` evalVal y
+  div x y = division (MulValue' (Constant' $ BigInt.fromInt marloweFixedPoint) x) y -- different rounding, not using DivValue
+  mod x y = Constant' $ (BigInt.fromInt marloweFixedPoint) * (evalVal x `mod` evalVal y)
 
 instance ActusOps Value' where
   _min x y = Cond' (ValueLT' x y) x y
@@ -126,11 +126,10 @@ marloweFixedPoint = 1000000
 
 division :: Value' -> Value' -> Value'
 division lhs rhs =
-  do
-    let
-      n = evalVal lhs
-      d = evalVal rhs
-    Constant' (division' n d)
+  let
+    n = evalVal lhs
+    d = evalVal rhs
+  in Constant' $ division' n d
   where
   division' :: BigInt -> BigInt -> BigInt
   division' x _ | x == BigInt.fromInt 0 = BigInt.fromInt 0

--- a/src/Actus/Model/Payoff.purs
+++ b/src/Actus/Model/Payoff.purs
@@ -18,7 +18,7 @@ type CtxPOF a =
     contractTerms :: ContractTerms a
   ,
     -- | Risk factors as a function of event type and time
-    riskFactors :: String -> EventType -> DateTime -> RiskFactors a
+    riskFactors :: EventType -> DateTime -> RiskFactors a
   }
 
 -- | The payoff function
@@ -36,7 +36,7 @@ payoff
   ->
   -- | Updated contract state
   Reader (CtxPOF a) a
-payoff (ev /\ t) st = asks $ do \ctx -> let terms@(ContractTerms ct :: ContractTerms a) = ctx.contractTerms in pof ev (ctx.riskFactors ct.contractId ev t) terms st
+payoff (ev /\ t) st = asks $ do \ctx -> let terms@(ContractTerms ct :: ContractTerms a) = ctx.contractTerms in pof ev (ctx.riskFactors ev t) terms st
   where
   ----------------------------
   -- Initial Exchange (IED) --

--- a/src/Actus/Model/StateTransistion.purs
+++ b/src/Actus/Model/StateTransistion.purs
@@ -37,7 +37,7 @@ type CtxSTF a =
     maturity :: Maybe DateTime
   ,
     -- | Riskfactors per event and time
-    riskFactors :: String -> EventType -> DateTime -> RiskFactors a
+    riskFactors :: EventType -> DateTime -> RiskFactors a
   }
 
 -- |A state transition updates the contract state based on the type of event and the time.
@@ -60,7 +60,7 @@ stateTransition
   Reader (CtxSTF a) (ContractState a)
 stateTransition ev t sn = asks stateTransition'
   where
-  stateTransition' ctx = let (ContractTerms ct') = ctx.contractTerms in stf ev (ctx.riskFactors ct'.contractId ev t) ctx.contractTerms sn
+  stateTransition' ctx = stf ev (ctx.riskFactors ev t) ctx.contractTerms sn
     where
     stf AD _ ct st = _STF_AD_ALL ct st t
     stf IED _ ct@(ContractTerms { contractType: PAM }) st = _STF_IED_PAM ct st t

--- a/src/Marlowe/Actus.purs
+++ b/src/Marlowe/Actus.purs
@@ -5,7 +5,7 @@ module Marlowe.Actus
   , ContractTermsMarlowe
   , RiskFactorsMarlowe
   , genContract
-  -- == Conversion from Number to Marlowe representation
+  -- == Conversion from Decimal to Marlowe representation
   -- re-export
   -- utility
   , toMarlowe
@@ -16,10 +16,12 @@ import Prelude
 import Actus.Core (genProjectedCashflows)
 import Actus.Domain (CashFlow(..), ContractState, ContractTerms(..), EventType, Observation'(..), RiskFactors, Value'(..), marloweFixedPoint)
 import Data.BigInt.Argonaut (BigInt, fromInt)
+import Data.BigInt.Argonaut as BigInt
 import Data.DateTime (DateTime)
 import Data.DateTime.Instant (Instant, fromDateTime)
+import Data.Decimal (Decimal)
+import Data.Decimal as Decimal
 import Data.Foldable (foldl)
-import Data.Int (round)
 import Data.List (reverse)
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested (type (/\), (/\))
@@ -222,13 +224,7 @@ hasRiskFactor cf@(CashFlow { amount }) = hasRiskFactor' amount
   hasRiskFactor' TimeIntervalEnd = false
   hasRiskFactor' (Cond _ a b) = hasRiskFactor' a || hasRiskFactor' b
 
-constant :: Number -> Value'
-constant n = Constant' $ toMarloweFixedPoint n
-  where
-  toMarloweFixedPoint :: Number -> BigInt
-  toMarloweFixedPoint x = marloweFixedPoint * fromInt (round x)
-
-toMarlowe :: ContractTerms Number -> ContractTermsMarlowe
+toMarlowe :: ContractTerms Decimal -> ContractTermsMarlowe
 toMarlowe (ContractTerms ct) =
   ContractTerms
     { contractId: ct.contractId
@@ -242,70 +238,76 @@ toMarlowe (ContractTerms ct) =
     , marketObjectCode: Nothing
     , contractPerformance: ct.contractPerformance
     , creditEventTypeCovered: ct.creditEventTypeCovered
-    , coverageOfCreditEnhancement: constant <$> ct.coverageOfCreditEnhancement
+    , coverageOfCreditEnhancement: constant =<< ct.coverageOfCreditEnhancement
     , guaranteedExposure: ct.guaranteedExposure
     , cycleOfFee: ct.cycleOfFee
     , cycleAnchorDateOfFee: ct.cycleAnchorDateOfFee
-    , feeAccrued: constant <$> ct.feeAccrued
+    , feeAccrued: constant =<< ct.feeAccrued
     , feeBasis: ct.feeBasis
-    , feeRate: constant <$> ct.feeRate
+    , feeRate: constant =<< ct.feeRate
     , cycleAnchorDateOfInterestPayment: ct.cycleAnchorDateOfInterestPayment
     , cycleOfInterestPayment: ct.cycleOfInterestPayment
-    , accruedInterest: constant <$> ct.accruedInterest
+    , accruedInterest: constant =<< ct.accruedInterest
     , capitalizationEndDate: ct.capitalizationEndDate
     , cycleAnchorDateOfInterestCalculationBase: ct.cycleAnchorDateOfInterestCalculationBase
     , cycleOfInterestCalculationBase: ct.cycleOfInterestCalculationBase
     , interestCalculationBase: ct.interestCalculationBase
-    , interestCalculationBaseAmount: constant <$> ct.interestCalculationBaseAmount
-    , nominalInterestRate: constant <$> ct.nominalInterestRate
-    , nominalInterestRate2: constant <$> ct.nominalInterestRate2
-    , interestScalingMultiplier: constant <$> ct.interestScalingMultiplier
-    , notionalPrincipal: constant <$> ct.notionalPrincipal
-    , premiumDiscountAtIED: constant <$> ct.premiumDiscountAtIED
+    , interestCalculationBaseAmount: constant =<< ct.interestCalculationBaseAmount
+    , nominalInterestRate: constant =<< ct.nominalInterestRate
+    , nominalInterestRate2: constant =<< ct.nominalInterestRate2
+    , interestScalingMultiplier: constant =<< ct.interestScalingMultiplier
+    , notionalPrincipal: constant =<< ct.notionalPrincipal
+    , premiumDiscountAtIED: constant =<< ct.premiumDiscountAtIED
     , maturityDate: ct.maturityDate
     , amortizationDate: ct.amortizationDate
     , exerciseDate: ct.exerciseDate
     , cycleAnchorDateOfPrincipalRedemption: ct.cycleAnchorDateOfPrincipalRedemption
     , cycleOfPrincipalRedemption: ct.cycleOfPrincipalRedemption
-    , nextPrincipalRedemptionPayment: constant <$> ct.nextPrincipalRedemptionPayment
+    , nextPrincipalRedemptionPayment: constant =<< ct.nextPrincipalRedemptionPayment
     , purchaseDate: ct.purchaseDate
-    , priceAtPurchaseDate: constant <$> ct.priceAtPurchaseDate
+    , priceAtPurchaseDate: constant =<< ct.priceAtPurchaseDate
     , terminationDate: ct.terminationDate
-    , priceAtTerminationDate: constant <$> ct.priceAtTerminationDate
-    , quantity: constant <$> ct.quantity
+    , priceAtTerminationDate: constant =<< ct.priceAtTerminationDate
+    , quantity: constant =<< ct.quantity
     , currency: ct.currency
     , currency2: ct.currency2
-    , scalingIndexAtStatusDate: constant <$> ct.scalingIndexAtStatusDate
+    , scalingIndexAtStatusDate: constant =<< ct.scalingIndexAtStatusDate
     , cycleAnchorDateOfScalingIndex: ct.cycleAnchorDateOfScalingIndex
     , cycleOfScalingIndex: ct.cycleOfScalingIndex
     , scalingEffect: ct.scalingEffect
-    , scalingIndexAtContractDealDate: constant <$> ct.scalingIndexAtContractDealDate
+    , scalingIndexAtContractDealDate: constant =<< ct.scalingIndexAtContractDealDate
     , marketObjectCodeOfScalingIndex: ct.marketObjectCodeOfScalingIndex
-    , notionalScalingMultiplier: constant <$> ct.notionalScalingMultiplier
+    , notionalScalingMultiplier: constant =<< ct.notionalScalingMultiplier
     , cycleOfOptionality: ct.cycleOfOptionality
     , cycleAnchorDateOfOptionality: ct.cycleAnchorDateOfOptionality
     , optionType: ct.optionType
-    , optionStrike1: constant <$> ct.optionStrike1
+    , optionStrike1: constant =<< ct.optionStrike1
     , optionExerciseType: ct.optionExerciseType
     , settlementPeriod: ct.settlementPeriod
     , deliverySettlement: ct.deliverySettlement
-    , exerciseAmount: constant <$> ct.exerciseAmount
-    , futuresPrice: constant <$> ct.futuresPrice
-    , penaltyRate: constant <$> ct.penaltyRate
+    , exerciseAmount: constant =<< ct.exerciseAmount
+    , futuresPrice: constant =<< ct.futuresPrice
+    , penaltyRate: constant =<< ct.penaltyRate
     , penaltyType: ct.penaltyType
     , prepaymentEffect: ct.prepaymentEffect
     , cycleOfRateReset: ct.cycleOfRateReset
     , cycleAnchorDateOfRateReset: ct.cycleAnchorDateOfRateReset
-    , nextResetRate: constant <$> ct.nextResetRate
-    , rateSpread: constant <$> ct.rateSpread
-    , rateMultiplier: constant <$> ct.rateMultiplier
-    , periodFloor: constant <$> ct.periodFloor
-    , periodCap: constant <$> ct.periodCap
-    , lifeCap: constant <$> ct.lifeCap
-    , lifeFloor: constant <$> ct.lifeFloor
+    , nextResetRate: constant =<< ct.nextResetRate
+    , rateSpread: constant =<< ct.rateSpread
+    , rateMultiplier: constant =<< ct.rateMultiplier
+    , periodFloor: constant =<< ct.periodFloor
+    , periodCap: constant =<< ct.periodCap
+    , lifeCap: constant =<< ct.lifeCap
+    , lifeFloor: constant =<< ct.lifeFloor
     , marketObjectCodeOfRateReset: ct.marketObjectCodeOfRateReset
     , cycleOfDividendPayment: ct.cycleOfDividendPayment
     , cycleAnchorDateOfDividendPayment: ct.cycleAnchorDateOfDividendPayment
-    , nextDividendPaymentAmount: constant <$> ct.nextDividendPaymentAmount
+    , nextDividendPaymentAmount: constant =<< ct.nextDividendPaymentAmount
     , enableSettlement: ct.enableSettlement
     }
+  where
+  constant :: Decimal -> Maybe Value'
+  constant n = Constant' <$> toMarloweFixedPoint n
+
+  toMarloweFixedPoint :: Decimal -> Maybe BigInt
+  toMarloweFixedPoint = BigInt.fromString <<< Decimal.toString <<< Decimal.floor <<< ((Decimal.fromInt marloweFixedPoint) * _)

--- a/src/Marlowe/Actus.purs
+++ b/src/Marlowe/Actus.purs
@@ -131,7 +131,7 @@ genContract
      Party /\ Party
   ->
   -- | Risk factors per event and time
-  (String -> EventType -> DateTime -> RiskFactorsMarlowe)
+  (EventType -> DateTime -> RiskFactorsMarlowe)
   ->
   -- | ACTUS contract terms
   ContractTermsMarlowe

--- a/test/Actus/TestFramework.purs
+++ b/test/Actus/TestFramework.purs
@@ -51,7 +51,7 @@ runTest tc =
   assertTestResults (cf : cfs) (r : rs) = assertTestResult cf r *> assertTestResults cfs rs
   assertTestResults _ _ = fail "Sizes differ"
 
-  assertTestResult :: forall m. MonadThrow Error m => CashFlow Decimal -> TestResult -> m Unit
+  assertTestResult :: forall m. MonadThrow Error m => CashFlow Decimal String -> TestResult -> m Unit
   assertTestResult (cf@(CashFlow { cashEvent, amount, cashPaymentDay })) (TestResult { eventType, payoff, eventDate }) = do
     assertEqual cashEvent eventType
     assertEqual cashPaymentDay eventDate
@@ -104,7 +104,7 @@ defaultRiskFactors = RiskFactors
   , pp_payoff: fromNumber 0.0
   }
 
-type TestCashFlow = CashFlow Decimal
+type TestCashFlow = CashFlow Decimal String
 type TestContractState = ContractState Decimal
 type TestContractTerms = ContractTerms Decimal
 

--- a/test/Actus/TestFramework.purs
+++ b/test/Actus/TestFramework.purs
@@ -62,8 +62,8 @@ runTest tc =
       | a == b = pure unit
       | otherwise = fail ("mismatch: " <> show tc.identifier <> " " <> show cf <> "\n" <> show a <> " vs. " <> show b <> "\n" <> show tc.terms)
 
-  riskFactors i ev date =
-    case getValue i tc ev date of
+  riskFactors ev date =
+    case getValue tc ev date of
       Just v -> case ev of
         RR -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_RRMO = v }
         SC -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_SCMO = v }
@@ -72,8 +72,8 @@ runTest tc =
         _ -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_CURS = v }
       Nothing -> defaultRiskFactors
 
-getValue :: String -> TestCase -> EventType -> DateTime -> Maybe Decimal
-getValue _ { terms, dataObserved } ev date =
+getValue :: TestCase -> EventType -> DateTime -> Maybe Decimal
+getValue { terms, dataObserved } ev date =
   do
     let (ContractTerms ct) = terms
     key <- observedKey terms ev

--- a/test/Actus/TestFramework.purs
+++ b/test/Actus/TestFramework.purs
@@ -41,7 +41,7 @@ spec fixture = do
 runTest :: forall a. MonadThrow Error a => TestCase -> a Unit
 runTest tc =
   let
-    cashFlows = genProjectedCashflows riskFactors (setDefaultContractTermValues tc.terms)
+    cashFlows = genProjectedCashflows ("party" /\ "counterparty") riskFactors (setDefaultContractTermValues tc.terms)
     cashFlowsTo = filter (\(CashFlow { cashPaymentDay }) -> isNothing tc.to || Just cashPaymentDay <= tc.to) cashFlows
   in
     assertTestResults cashFlowsTo tc.results
@@ -67,8 +67,6 @@ runTest tc =
       Just v -> case ev of
         RR -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_RRMO = v }
         SC -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_SCMO = v }
-        DV -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { dv_payoff = v }
-        XD -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { xd_payoff = v }
         _ -> let RiskFactors rf = defaultRiskFactors in RiskFactors $ rf { o_rf_CURS = v }
       Nothing -> defaultRiskFactors
 
@@ -104,8 +102,6 @@ defaultRiskFactors = RiskFactors
   , o_rf_RRMO: fromNumber 1.0
   , o_rf_SCMO: fromNumber 1.0
   , pp_payoff: fromNumber 0.0
-  , xd_payoff: fromNumber 0.0
-  , dv_payoff: fromNumber 0.0
   }
 
 type TestCashFlow = CashFlow Decimal

--- a/test/Actus/TestFramework.purs
+++ b/test/Actus/TestFramework.purs
@@ -42,7 +42,7 @@ runTest :: forall a. MonadThrow Error a => TestCase -> a Unit
 runTest tc =
   let
     cashFlows = genProjectedCashflows ("party" /\ "counterparty") riskFactors (setDefaultContractTermValues tc.terms)
-    cashFlowsTo = filter (\(CashFlow { cashPaymentDay }) -> isNothing tc.to || Just cashPaymentDay <= tc.to) cashFlows
+    cashFlowsTo = filter (\(CashFlow { paymentDay }) -> isNothing tc.to || Just paymentDay <= tc.to) cashFlows
   in
     assertTestResults cashFlowsTo tc.results
   where
@@ -52,9 +52,9 @@ runTest tc =
   assertTestResults _ _ = fail "Sizes differ"
 
   assertTestResult :: forall m. MonadThrow Error m => CashFlow Decimal String -> TestResult -> m Unit
-  assertTestResult (cf@(CashFlow { cashEvent, amount, cashPaymentDay })) (TestResult { eventType, payoff, eventDate }) = do
-    assertEqual cashEvent eventType
-    assertEqual cashPaymentDay eventDate
+  assertTestResult (cf@(CashFlow { event, amount, paymentDay })) (TestResult { eventType, payoff, eventDate }) = do
+    assertEqual event eventType
+    assertEqual paymentDay eventDate
     assertEqual (toSignificantDigits 8 amount) (toSignificantDigits 8 payoff)
     where
     assertEqual :: forall b n. Show b => Eq b => MonadThrow Error n => b -> b -> n Unit
@@ -200,10 +200,6 @@ newtype TestResult = TestResult
   , eventType :: EventType
   , payoff :: Decimal
   , currency :: String
-  -- notionalPrincipal   :: Decimal
-  -- exerciseAmount      :: Maybe Decimal,
-  -- nominalInterestRate :: Maybe Decimal,
-  -- accruedInterest     :: Maybe Decimal
   }
 
 instance DecodeJson TestResult where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -20,6 +20,7 @@ import Foreign.Object as Object
 import Marlowe.Runtime.Web.Types (ServerURL(..))
 import Node.Process (getEnv)
 import Test.Actus.Domain.ContractTerms as ContractTerms
+import Test.Marlowe.Actus as MarloweActus
 import Test.Marlowe.Runtime.Web (_MARLOWE_WEB_SERVER_URL)
 import Test.Marlowe.Runtime.Web as Web
 import Test.Spec as Spec
@@ -39,11 +40,12 @@ main = do
     runSpec [ consoleReporter ] $ do
       Spec.parallel do
         ContractTerms.spec
-        Web.spec serverUrlStr
         TestFramework.spec testsPAM
         TestFramework.spec testsLAM
         TestFramework.spec testsNAM
         TestFramework.spec testsANN
+        MarloweActus.spec
+        Web.spec serverUrlStr
 
   where
   readFile file = do

--- a/test/Marlowe/Actus.purs
+++ b/test/Marlowe/Actus.purs
@@ -1,0 +1,51 @@
+module Test.Marlowe.Actus where
+
+import Prelude
+
+import Actus.Domain (ContractTerms, EventType, RiskFactors(..), Value'(..), marloweFixedPoint)
+import Control.Monad.Error.Class (throwError)
+import Data.Argonaut (JsonDecodeError, decodeJson, encodeJson, jsonParser, stringify)
+import Data.BigInt.Argonaut as BigInt
+import Data.DateTime (DateTime)
+import Data.Decimal (Decimal)
+import Data.Either (Either(..), either)
+import Data.Tuple.Nested ((/\))
+import Effect.Exception (error)
+import Language.Marlowe.Core.V1.Semantics.Types (Party(..))
+import Marlowe.Actus (genContract, toMarlowe)
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff (writeTextFile, readTextFile)
+import Test.Spec (Spec, describe, it)
+import Test.Spec as Spec
+import Test.Spec.Assertions (fail)
+
+spec :: Spec Unit
+spec = do
+  describe "Marlowe.Actus" $ Spec.parallel do
+    it "Contract generation" do
+      jsonStr <- readTextFile UTF8 "./test/Marlowe/Actus/pam01.json"
+      json <- either (throwError <<< error) pure $ jsonParser jsonStr
+
+      let
+        (terms :: Either JsonDecodeError (ContractTerms Decimal)) = decodeJson json
+      case terms of
+        Left err -> fail (show err)
+        Right contractA -> do
+          let
+            contractM = toMarlowe contractA
+            p1 = Address "addr1"
+            p2 = Address "addr2"
+            marloweContract = genContract (p1 /\ p2) riskFactors contractM
+
+          writeTextFile UTF8 "out.json" (stringify $ encodeJson marloweContract)
+          pure unit
+
+riskFactors :: EventType -> DateTime -> RiskFactors Value'
+riskFactors _ _ = RiskFactors
+  { o_rf_CURS: fromInt 1
+  , o_rf_RRMO: fromInt 1
+  , o_rf_SCMO: fromInt 1
+  , pp_payoff: fromInt 0
+  }
+  where
+  fromInt = Constant' <<< BigInt.fromInt <<< (marloweFixedPoint * _)

--- a/test/Marlowe/Actus/pam01.json
+++ b/test/Marlowe/Actus/pam01.json
@@ -1,0 +1,18 @@
+{
+    "contractType": "PAM",
+    "contractID": "pam01",
+    "statusDate": "2012-12-30T00:00:00",
+    "contractDealDate": "2012-12-28T00:00:00",
+    "currency": "USD",
+    "notionalPrincipal": "3000",
+    "initialExchangeDate": "2013-01-01T00:00:00",
+    "maturityDate": "2014-01-01T00:00:00",
+    "nominalInterestRate": "0.1",
+    "cycleAnchorDateOfInterestPayment": "2013-01-01T00:00:00",
+    "cycleOfInterestPayment": "P1ML0",
+    "dayCountConvention": "A365",
+    "endOfMonthConvention": "SD",
+    "premiumDiscountAtIED": "   0",
+    "rateMultiplier": "1.0",
+    "contractRole": "RPA"
+}

--- a/test/Marlowe/Actus/pam24.json
+++ b/test/Marlowe/Actus/pam24.json
@@ -1,0 +1,22 @@
+{
+    "contractType": "PAM",
+    "contractID": "pam24",
+    "statusDate": "2012-12-30T00:00:00",
+    "contractDealDate": "2012-12-28T00:00:00",
+    "currency": "USD",
+    "notionalPrincipal": "3000",
+    "initialExchangeDate": "2013-01-01T00:00:00",
+    "maturityDate": "2014-01-01T00:00:00",
+    "nominalInterestRate": "0.1",
+    "cycleAnchorDateOfInterestPayment": "2013-01-01T00:00:00",
+    "cycleOfInterestPayment": "P1ML0",
+    "cycleAnchorDateOfRateReset": "2013-05-20T00:00:00",
+    "cycleOfRateReset": "P29DL0",
+    "rateSpread": "0.02",
+    "marketObjectCodeOfRateReset": "USD_SWP",
+    "dayCountConvention": "30E360",
+    "endOfMonthConvention": "SD",
+    "premiumDiscountAtIED": "-200",
+    "rateMultiplier": "1.0",
+    "contractRole": "RPA"
+}


### PR DESCRIPTION
The PR introduces a fix for the `EuclideanRing` instance of the Marlowe data types. This resolves issues that arouse from wrong results of division. 

Apart from that, there are some small refactorings of the code.