### PR TITLE
SCP 4795: ACTUS contract terms encoding for metadata

### DIFF
--- a/src/Actus/Domain/ContractTerms.purs
+++ b/src/Actus/Domain/ContractTerms.purs
@@ -810,8 +810,6 @@ newtype ContractTerms a = ContractTerms
   , cycleOfDividendPayment :: Maybe Cycle -- ^ Cycle Of Dividend
   , cycleAnchorDateOfDividendPayment :: Maybe DateTime -- ^ Cycle Anchor Date Of Dividend
   , nextDividendPaymentAmount :: Maybe a -- ^ Next Dividend Payment Amount
-
-  , enableSettlement :: Boolean -- ^ Enable settlement currency
   }
 
 derive instance Newtype (ContractTerms a) _
@@ -950,5 +948,3 @@ instance DecodeJson (ContractTerms Decimal) where
       (Proxy :: Proxy "cycleOfDividendPayment") :=? decodeFromString decodeCycle
       (Proxy :: Proxy "cycleAnchorDateOfDividendPayment") :=? decodeDateTime
       (Proxy :: Proxy "nextDividendPaymentAmount") :=? decodeDecimal
-
-      (Proxy :: Proxy "enableSettlement") :=! decodeJson $ false

--- a/src/Actus/Domain/ContractTerms.purs
+++ b/src/Actus/Domain/ContractTerms.purs
@@ -823,6 +823,9 @@ instance Show a => Show (ContractTerms a) where
 decodeDecimal :: Json -> Either JsonDecodeError Decimal
 decodeDecimal = decodeFromString (String.trimStart >>> Decimal.fromString)
 
+encodeDecimal :: Decimal -> Json
+encodeDecimal = fromString <<< Decimal.toString
+
 decodeDateTime :: Json -> Either JsonDecodeError DateTime
 decodeDateTime json = do
   str <- decodeJson json

--- a/src/Marlowe/Actus.purs
+++ b/src/Marlowe/Actus.purs
@@ -299,7 +299,6 @@ toMarlowe (ContractTerms ct) =
     , cycleOfDividendPayment: ct.cycleOfDividendPayment
     , cycleAnchorDateOfDividendPayment: ct.cycleAnchorDateOfDividendPayment
     , nextDividendPaymentAmount: constant =<< ct.nextDividendPaymentAmount
-    , enableSettlement: ct.enableSettlement
     }
   where
   constant :: Decimal -> Maybe Value'

--- a/src/Marlowe/Actus/Metadata.purs
+++ b/src/Marlowe/Actus/Metadata.purs
@@ -26,6 +26,8 @@ encodeDateTime = instantToJson <<< fromDateTime
 decodeDateTime :: Json -> Either JsonDecodeError DateTime
 decodeDateTime json = rmap toDateTime (instantFromJson json)
 
+-- Using acronyms from `actus-dictionary-terms.json` for encoding/decoding
+-- https://github.com/actusfrf/actus-dictionary
 instance EncodeJson (Metadata Decimal) where
   encodeJson (Metadata (ContractTerms ct)) =
     "cid" := ct.contractId

--- a/src/Marlowe/Actus/Metadata.purs
+++ b/src/Marlowe/Actus/Metadata.purs
@@ -1,0 +1,101 @@
+module Marlowe.Actus.Metadata where
+
+import Prelude
+
+import Actus.Domain.ContractTerms (ContractTerms(..), encodeCycle)
+import Data.Argonaut (Json, encodeJson, fromString, jsonEmptyObject, (:=), (:=?), (~>), (~>?))
+import Data.Argonaut.Encode.Class (class EncodeJson)
+import Data.DateTime (DateTime)
+import Data.DateTime.Instant (fromDateTime, unInstant)
+import Data.Decimal (Decimal, toString)
+import Data.Generic.Rep (class Generic)
+import Data.Newtype (unwrap)
+
+newtype Metadata value = Metadata (ContractTerms value)
+derive instance Generic (Metadata value) _
+
+instance EncodeJson (Metadata Decimal) where
+  encodeJson (Metadata (ContractTerms ct)) =
+       "cid" := ct.contractId
+    ~> "ct" := ct.contractType
+    ~> "cntrl" := ct.contractRole
+    ~> "curs" :=? ct.settlementCurrency
+    ~>? "ied" :=? (encodeDateTime <$> ct.initialExchangeDate)
+    ~>? "dcc" :=? ct.dayCountConvention
+    ~>? "sc" := ct.scheduleConfig 
+    ~> "sd" := (encodeDateTime ct.statusDate)
+    ~> "moc" :=? ct.marketObjectCode
+    ~>? "prf" :=? ct.contractPerformance 
+    ~>? "cetc" :=? ct.creditEventTypeCovered 
+    ~>? "cecv" :=? (encodeDecimal <$> ct.coverageOfCreditEnhancement)
+    ~>? "cege" :=? ct.guaranteedExposure 
+    ~>? "fecl" :=? (encodeCycle <$> ct.cycleOfFee)
+    ~>? "feanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfFee)
+    ~>? "feac" :=? (encodeDecimal <$> ct.feeAccrued)
+    ~>? "feb" :=? ct.feeBasis
+    ~>? "fer" :=? (encodeDecimal <$> ct.feeRate)
+    ~>? "ipanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestPayment)
+    ~>? "ipcl" :=? (encodeCycle <$> ct.cycleOfInterestPayment)
+    ~>? "ipac" :=? (encodeDecimal <$> ct.accruedInterest)
+    ~>? "ipced" :=? (encodeDateTime <$> ct.capitalizationEndDate)
+    ~>? "ipcbanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestCalculationBase)
+    ~>? "ipcbcl" :=? (encodeCycle <$> ct.cycleOfInterestCalculationBase)
+    ~>? "ipcb" :=? ct.interestCalculationBase 
+    ~>? "ipcba" :=? (encodeDecimal <$> ct.interestCalculationBaseAmount)
+    ~>? "ipnr" :=? (encodeDecimal <$> ct.nominalInterestRate)
+    ~>? "ipnr2" :=? (encodeDecimal <$> ct.nominalInterestRate2) 
+    ~>? "scip" :=? (encodeDecimal <$> ct.interestScalingMultiplier) 
+    ~>? "md" :=? (encodeDateTime <$> ct.maturityDate)
+    ~>? "ad" :=? (encodeDateTime <$> ct.amortizationDate)
+    ~>? "xd" :=? (encodeDateTime <$> ct.exerciseDate)
+    ~>? "nt" :=? (encodeDecimal <$> ct.notionalPrincipal)
+    ~>? "pdied" :=? (encodeDecimal <$> ct.premiumDiscountAtIED)
+    ~>? "pranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfPrincipalRedemption)
+    ~>? "prcl" :=? (encodeCycle <$> ct.cycleOfPrincipalRedemption)
+    ~>? "prnxt" :=? (encodeDecimal <$> ct.nextPrincipalRedemptionPayment)
+    ~>? "prd" :=? (encodeDateTime <$> ct.purchaseDate)
+    ~>? "pprd" :=? (encodeDecimal <$> ct.priceAtPurchaseDate) 
+    ~>? "td" :=? (encodeDateTime <$> ct.terminationDate)
+    ~>? "ptd" :=? (encodeDecimal <$> ct.priceAtTerminationDate)
+    ~>? "qt" :=? (encodeDecimal <$> ct.quantity)
+    ~>? "cur" :=? ct.currency
+    ~>? "cur2" :=? ct.currency2
+    ~>? "scsd" :=? (encodeDecimal <$> ct.scalingIndexAtStatusDate)
+    ~>? "scanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfScalingIndex)
+    ~>? "sccl" :=? (encodeCycle <$> ct.cycleOfScalingIndex)
+    ~>? "scef" :=? ct.scalingEffect
+    ~>? "sccdd" :=? (encodeDecimal <$> ct.scalingIndexAtContractDealDate)
+    ~>? "scmo" :=? ct.marketObjectCodeOfScalingIndex 
+    ~>? "scnt" :=? (encodeDecimal <$> ct.notionalScalingMultiplier)
+    ~>? "opcl" :=? (encodeCycle <$> ct.cycleOfOptionality)
+    ~>? "opanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfOptionality)
+    ~>? "optp" :=? ct.optionType 
+    ~>? "ops1" :=? (encodeDecimal <$> ct.optionStrike1)
+    ~>? "opxt" :=? ct.optionExerciseType 
+    ~>? "stp" :=? (encodeCycle <$> ct.settlementPeriod)
+    ~>? "ds" :=? ct.deliverySettlement 
+    ~>? "xa" :=? (encodeDecimal <$> ct.exerciseAmount)
+    ~>? "pfut" :=? (encodeDecimal <$> ct.futuresPrice)
+    ~>? "pyrt" :=? (encodeDecimal <$> ct.penaltyRate)
+    ~>? "pytp" :=? ct.penaltyType 
+    ~>? "ppef" :=? ct.prepaymentEffect 
+    ~>? "rrcl" :=? (encodeCycle <$> ct.cycleOfRateReset)
+    ~>? "rranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfRateReset)
+    ~>? "rrnxt" :=? (encodeDecimal <$> ct.nextResetRate)
+    ~>? "rrsp" :=? (encodeDecimal <$> ct.rateSpread)
+    ~>? "rrmlt" :=? (encodeDecimal <$> ct.rateMultiplier)
+    ~>? "rrpf" :=? (encodeDecimal <$> ct.periodFloor)
+    ~>? "rrpc" :=? (encodeDecimal <$> ct.periodCap)
+    ~>? "rrlc" :=? (encodeDecimal <$> ct.lifeCap)
+    ~>? "rrlf" :=? (encodeDecimal <$> ct.lifeFloor)
+    ~>? "rrmo" :=? ct.marketObjectCodeOfRateReset
+    ~>? "dvcl" :=? (encodeCycle <$> ct.cycleOfDividendPayment)
+    ~>? "dvanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfDividendPayment)
+    ~>? "dvnxt" :=? (encodeDecimal <$> ct.nextDividendPaymentAmount)
+    ~>? jsonEmptyObject
+
+encodeDecimal :: Decimal -> Json
+encodeDecimal = fromString <<< toString
+
+encodeDateTime :: DateTime -> Json
+encodeDateTime = encodeJson <<< unwrap <<< unInstant <<< fromDateTime

--- a/src/Marlowe/Actus/Metadata.purs
+++ b/src/Marlowe/Actus/Metadata.purs
@@ -17,6 +17,7 @@ import Marlowe.Time (instantFromJson, instantToJson)
 
 newtype Metadata value = Metadata (ContractTerms value)
 
+derive instance Eq a => Eq (Metadata a)
 derive instance Generic (Metadata value) _
 
 encodeDateTime :: DateTime -> Json
@@ -265,5 +266,4 @@ instance DecodeJson (Metadata Decimal) where
       , cycleOfDividendPayment
       , cycleAnchorDateOfDividendPayment
       , nextDividendPaymentAmount
-      , enableSettlement: false
       }

--- a/src/Marlowe/Actus/Metadata.purs
+++ b/src/Marlowe/Actus/Metadata.purs
@@ -2,100 +2,268 @@ module Marlowe.Actus.Metadata where
 
 import Prelude
 
-import Actus.Domain.ContractTerms (ContractTerms(..), encodeCycle)
-import Data.Argonaut (Json, encodeJson, fromString, jsonEmptyObject, (:=), (:=?), (~>), (~>?))
+import Actus.Domain.ContractTerms (ContractTerms(..), decodeCycle, decodeDecimal, encodeCycle, encodeDecimal)
+import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, jsonEmptyObject, (.:), (.:?), (:=), (:=?), (~>), (~>?))
+import Data.Argonaut.Decode.Decoders as Decoders
 import Data.Argonaut.Encode.Class (class EncodeJson)
+import Data.Bifunctor (rmap)
 import Data.DateTime (DateTime)
-import Data.DateTime.Instant (fromDateTime, unInstant)
-import Data.Decimal (Decimal, toString)
+import Data.DateTime.Instant (fromDateTime, toDateTime)
+import Data.Decimal (Decimal)
+import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
-import Data.Newtype (unwrap)
+import Data.Maybe (Maybe)
+import Marlowe.Time (instantFromJson, instantToJson)
 
 newtype Metadata value = Metadata (ContractTerms value)
+
 derive instance Generic (Metadata value) _
+
+encodeDateTime :: DateTime -> Json
+encodeDateTime = instantToJson <<< fromDateTime
+
+decodeDateTime :: Json -> Either JsonDecodeError DateTime
+decodeDateTime json = rmap toDateTime (instantFromJson json)
 
 instance EncodeJson (Metadata Decimal) where
   encodeJson (Metadata (ContractTerms ct)) =
-       "cid" := ct.contractId
-    ~> "ct" := ct.contractType
-    ~> "cntrl" := ct.contractRole
-    ~> "curs" :=? ct.settlementCurrency
-    ~>? "ied" :=? (encodeDateTime <$> ct.initialExchangeDate)
-    ~>? "dcc" :=? ct.dayCountConvention
-    ~>? "sc" := ct.scheduleConfig 
-    ~> "sd" := (encodeDateTime ct.statusDate)
-    ~> "moc" :=? ct.marketObjectCode
-    ~>? "prf" :=? ct.contractPerformance 
-    ~>? "cetc" :=? ct.creditEventTypeCovered 
-    ~>? "cecv" :=? (encodeDecimal <$> ct.coverageOfCreditEnhancement)
-    ~>? "cege" :=? ct.guaranteedExposure 
-    ~>? "fecl" :=? (encodeCycle <$> ct.cycleOfFee)
-    ~>? "feanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfFee)
-    ~>? "feac" :=? (encodeDecimal <$> ct.feeAccrued)
-    ~>? "feb" :=? ct.feeBasis
-    ~>? "fer" :=? (encodeDecimal <$> ct.feeRate)
-    ~>? "ipanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestPayment)
-    ~>? "ipcl" :=? (encodeCycle <$> ct.cycleOfInterestPayment)
-    ~>? "ipac" :=? (encodeDecimal <$> ct.accruedInterest)
-    ~>? "ipced" :=? (encodeDateTime <$> ct.capitalizationEndDate)
-    ~>? "ipcbanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestCalculationBase)
-    ~>? "ipcbcl" :=? (encodeCycle <$> ct.cycleOfInterestCalculationBase)
-    ~>? "ipcb" :=? ct.interestCalculationBase 
-    ~>? "ipcba" :=? (encodeDecimal <$> ct.interestCalculationBaseAmount)
-    ~>? "ipnr" :=? (encodeDecimal <$> ct.nominalInterestRate)
-    ~>? "ipnr2" :=? (encodeDecimal <$> ct.nominalInterestRate2) 
-    ~>? "scip" :=? (encodeDecimal <$> ct.interestScalingMultiplier) 
-    ~>? "md" :=? (encodeDateTime <$> ct.maturityDate)
-    ~>? "ad" :=? (encodeDateTime <$> ct.amortizationDate)
-    ~>? "xd" :=? (encodeDateTime <$> ct.exerciseDate)
-    ~>? "nt" :=? (encodeDecimal <$> ct.notionalPrincipal)
-    ~>? "pdied" :=? (encodeDecimal <$> ct.premiumDiscountAtIED)
-    ~>? "pranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfPrincipalRedemption)
-    ~>? "prcl" :=? (encodeCycle <$> ct.cycleOfPrincipalRedemption)
-    ~>? "prnxt" :=? (encodeDecimal <$> ct.nextPrincipalRedemptionPayment)
-    ~>? "prd" :=? (encodeDateTime <$> ct.purchaseDate)
-    ~>? "pprd" :=? (encodeDecimal <$> ct.priceAtPurchaseDate) 
-    ~>? "td" :=? (encodeDateTime <$> ct.terminationDate)
-    ~>? "ptd" :=? (encodeDecimal <$> ct.priceAtTerminationDate)
-    ~>? "qt" :=? (encodeDecimal <$> ct.quantity)
-    ~>? "cur" :=? ct.currency
-    ~>? "cur2" :=? ct.currency2
-    ~>? "scsd" :=? (encodeDecimal <$> ct.scalingIndexAtStatusDate)
-    ~>? "scanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfScalingIndex)
-    ~>? "sccl" :=? (encodeCycle <$> ct.cycleOfScalingIndex)
-    ~>? "scef" :=? ct.scalingEffect
-    ~>? "sccdd" :=? (encodeDecimal <$> ct.scalingIndexAtContractDealDate)
-    ~>? "scmo" :=? ct.marketObjectCodeOfScalingIndex 
-    ~>? "scnt" :=? (encodeDecimal <$> ct.notionalScalingMultiplier)
-    ~>? "opcl" :=? (encodeCycle <$> ct.cycleOfOptionality)
-    ~>? "opanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfOptionality)
-    ~>? "optp" :=? ct.optionType 
-    ~>? "ops1" :=? (encodeDecimal <$> ct.optionStrike1)
-    ~>? "opxt" :=? ct.optionExerciseType 
-    ~>? "stp" :=? (encodeCycle <$> ct.settlementPeriod)
-    ~>? "ds" :=? ct.deliverySettlement 
-    ~>? "xa" :=? (encodeDecimal <$> ct.exerciseAmount)
-    ~>? "pfut" :=? (encodeDecimal <$> ct.futuresPrice)
-    ~>? "pyrt" :=? (encodeDecimal <$> ct.penaltyRate)
-    ~>? "pytp" :=? ct.penaltyType 
-    ~>? "ppef" :=? ct.prepaymentEffect 
-    ~>? "rrcl" :=? (encodeCycle <$> ct.cycleOfRateReset)
-    ~>? "rranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfRateReset)
-    ~>? "rrnxt" :=? (encodeDecimal <$> ct.nextResetRate)
-    ~>? "rrsp" :=? (encodeDecimal <$> ct.rateSpread)
-    ~>? "rrmlt" :=? (encodeDecimal <$> ct.rateMultiplier)
-    ~>? "rrpf" :=? (encodeDecimal <$> ct.periodFloor)
-    ~>? "rrpc" :=? (encodeDecimal <$> ct.periodCap)
-    ~>? "rrlc" :=? (encodeDecimal <$> ct.lifeCap)
-    ~>? "rrlf" :=? (encodeDecimal <$> ct.lifeFloor)
-    ~>? "rrmo" :=? ct.marketObjectCodeOfRateReset
-    ~>? "dvcl" :=? (encodeCycle <$> ct.cycleOfDividendPayment)
-    ~>? "dvanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfDividendPayment)
-    ~>? "dvnxt" :=? (encodeDecimal <$> ct.nextDividendPaymentAmount)
-    ~>? jsonEmptyObject
+    "cid" := ct.contractId
+      ~> "ct" := ct.contractType
+      ~> "cntrl" := ct.contractRole
+      ~> "curs" :=? ct.settlementCurrency
+      ~>? "ied" :=? (encodeDateTime <$> ct.initialExchangeDate)
+      ~>? "dcc" :=? ct.dayCountConvention
+      ~>? "cal" :=? ct.scheduleConfig.calendar
+      ~>? "emoc" :=? ct.scheduleConfig.endOfMonthConvention
+      ~>? "bdc" :=? ct.scheduleConfig.businessDayConvention
+      ~>? "sd" := (encodeDateTime ct.statusDate)
+      ~> "moc" :=? ct.marketObjectCode
+      ~>? "prf" :=? ct.contractPerformance
+      ~>? "cetc" :=? ct.creditEventTypeCovered
+      ~>? "cecv" :=? (encodeDecimal <$> ct.coverageOfCreditEnhancement)
+      ~>? "cege" :=? ct.guaranteedExposure
+      ~>? "fecl" :=? (encodeCycle <$> ct.cycleOfFee)
+      ~>? "feanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfFee)
+      ~>? "feac" :=? (encodeDecimal <$> ct.feeAccrued)
+      ~>? "feb" :=? ct.feeBasis
+      ~>? "fer" :=? (encodeDecimal <$> ct.feeRate)
+      ~>? "ipanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestPayment)
+      ~>? "ipcl" :=? (encodeCycle <$> ct.cycleOfInterestPayment)
+      ~>? "ipac" :=? (encodeDecimal <$> ct.accruedInterest)
+      ~>? "ipced" :=? (encodeDateTime <$> ct.capitalizationEndDate)
+      ~>? "ipcbanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfInterestCalculationBase)
+      ~>? "ipcbcl" :=? (encodeCycle <$> ct.cycleOfInterestCalculationBase)
+      ~>? "ipcb" :=? ct.interestCalculationBase
+      ~>? "ipcba" :=? (encodeDecimal <$> ct.interestCalculationBaseAmount)
+      ~>? "ipnr" :=? (encodeDecimal <$> ct.nominalInterestRate)
+      ~>? "ipnr2" :=? (encodeDecimal <$> ct.nominalInterestRate2)
+      ~>? "scip" :=? (encodeDecimal <$> ct.interestScalingMultiplier)
+      ~>? "md" :=? (encodeDateTime <$> ct.maturityDate)
+      ~>? "ad" :=? (encodeDateTime <$> ct.amortizationDate)
+      ~>? "xd" :=? (encodeDateTime <$> ct.exerciseDate)
+      ~>? "nt" :=? (encodeDecimal <$> ct.notionalPrincipal)
+      ~>? "pdied" :=? (encodeDecimal <$> ct.premiumDiscountAtIED)
+      ~>? "pranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfPrincipalRedemption)
+      ~>? "prcl" :=? (encodeCycle <$> ct.cycleOfPrincipalRedemption)
+      ~>? "prnxt" :=? (encodeDecimal <$> ct.nextPrincipalRedemptionPayment)
+      ~>? "prd" :=? (encodeDateTime <$> ct.purchaseDate)
+      ~>? "pprd" :=? (encodeDecimal <$> ct.priceAtPurchaseDate)
+      ~>? "td" :=? (encodeDateTime <$> ct.terminationDate)
+      ~>? "ptd" :=? (encodeDecimal <$> ct.priceAtTerminationDate)
+      ~>? "qt" :=? (encodeDecimal <$> ct.quantity)
+      ~>? "cur" :=? ct.currency
+      ~>? "cur2" :=? ct.currency2
+      ~>? "scsd" :=? (encodeDecimal <$> ct.scalingIndexAtStatusDate)
+      ~>? "scanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfScalingIndex)
+      ~>? "sccl" :=? (encodeCycle <$> ct.cycleOfScalingIndex)
+      ~>? "scef" :=? ct.scalingEffect
+      ~>? "sccdd" :=? (encodeDecimal <$> ct.scalingIndexAtContractDealDate)
+      ~>? "scmo" :=? ct.marketObjectCodeOfScalingIndex
+      ~>? "scnt" :=? (encodeDecimal <$> ct.notionalScalingMultiplier)
+      ~>? "opcl" :=? (encodeCycle <$> ct.cycleOfOptionality)
+      ~>? "opanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfOptionality)
+      ~>? "optp" :=? ct.optionType
+      ~>? "ops1" :=? (encodeDecimal <$> ct.optionStrike1)
+      ~>? "opxt" :=? ct.optionExerciseType
+      ~>? "stp" :=? (encodeCycle <$> ct.settlementPeriod)
+      ~>? "ds" :=? ct.deliverySettlement
+      ~>? "xa" :=? (encodeDecimal <$> ct.exerciseAmount)
+      ~>? "pfut" :=? (encodeDecimal <$> ct.futuresPrice)
+      ~>? "pyrt" :=? (encodeDecimal <$> ct.penaltyRate)
+      ~>? "pytp" :=? ct.penaltyType
+      ~>? "ppef" :=? ct.prepaymentEffect
+      ~>? "rrcl" :=? (encodeCycle <$> ct.cycleOfRateReset)
+      ~>? "rranx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfRateReset)
+      ~>? "rrnxt" :=? (encodeDecimal <$> ct.nextResetRate)
+      ~>? "rrsp" :=? (encodeDecimal <$> ct.rateSpread)
+      ~>? "rrmlt" :=? (encodeDecimal <$> ct.rateMultiplier)
+      ~>? "rrpf" :=? (encodeDecimal <$> ct.periodFloor)
+      ~>? "rrpc" :=? (encodeDecimal <$> ct.periodCap)
+      ~>? "rrlc" :=? (encodeDecimal <$> ct.lifeCap)
+      ~>? "rrlf" :=? (encodeDecimal <$> ct.lifeFloor)
+      ~>? "rrmo" :=? ct.marketObjectCodeOfRateReset
+      ~>? "dvcl" :=? (encodeCycle <$> ct.cycleOfDividendPayment)
+      ~>? "dvanx" :=? (encodeDateTime <$> ct.cycleAnchorDateOfDividendPayment)
+      ~>? "dvnxt" :=? (encodeDecimal <$> ct.nextDividendPaymentAmount)
+      ~>? jsonEmptyObject
 
-encodeDecimal :: Decimal -> Json
-encodeDecimal = fromString <<< toString
-
-encodeDateTime :: DateTime -> Json
-encodeDateTime = encodeJson <<< unwrap <<< unInstant <<< fromDateTime
+instance DecodeJson (Metadata Decimal) where
+  decodeJson json = Metadata <$> do
+    obj <- decodeJson json
+    contractId <- obj .: "cid"
+    contractType <- obj .: "ct"
+    contractRole <- obj .: "cntrl"
+    settlementCurrency <- obj .:? "curs" :: Either JsonDecodeError (Maybe String)
+    initialExchangeDate <- Decoders.getFieldOptional' decodeDateTime obj "ied"
+    dayCountConvention <- obj .:? "dcc"
+    calendar <- obj .:? "cal"
+    endOfMonthConvention <- obj .:? "emoc"
+    businessDayConvention <- obj .:? "bdc"
+    statusDate <- obj .: "sd" >>= decodeDateTime
+    marketObjectCode <- obj .:? "moc"
+    contractPerformance <- obj .:? "prf"
+    creditEventTypeCovered <- obj .:? "cetc"
+    coverageOfCreditEnhancement <- Decoders.getFieldOptional' decodeDecimal obj "cecv"
+    guaranteedExposure <- obj .:? "cege"
+    cycleOfFee <- rmap (_ >>= decodeCycle) (obj .:? "fecl")
+    cycleAnchorDateOfFee <- Decoders.getFieldOptional' decodeDateTime obj "feanx"
+    feeAccrued <- Decoders.getFieldOptional' decodeDecimal obj "feac"
+    feeBasis <- obj .:? "feb"
+    feeRate <- Decoders.getFieldOptional' decodeDecimal obj "fer"
+    cycleAnchorDateOfInterestPayment <- Decoders.getFieldOptional' decodeDateTime obj "ipanx"
+    cycleOfInterestPayment <- rmap (_ >>= decodeCycle) (obj .:? "ipcl")
+    accruedInterest <- Decoders.getFieldOptional' decodeDecimal obj "ipac"
+    capitalizationEndDate <- Decoders.getFieldOptional' decodeDateTime obj "ipced"
+    cycleAnchorDateOfInterestCalculationBase <- Decoders.getFieldOptional' decodeDateTime obj "ipcbanx"
+    cycleOfInterestCalculationBase <- rmap (_ >>= decodeCycle) (obj .:? "ipcbcl")
+    interestCalculationBase <- obj .:? "ipcb"
+    interestCalculationBaseAmount <- Decoders.getFieldOptional' decodeDecimal obj "ipcba"
+    nominalInterestRate <- Decoders.getFieldOptional' decodeDecimal obj "ipnr"
+    nominalInterestRate2 <- Decoders.getFieldOptional' decodeDecimal obj "ipnr2"
+    interestScalingMultiplier <- Decoders.getFieldOptional' decodeDecimal obj "scip"
+    maturityDate <- Decoders.getFieldOptional' decodeDateTime obj "md"
+    amortizationDate <- Decoders.getFieldOptional' decodeDateTime obj "ad"
+    exerciseDate <- Decoders.getFieldOptional' decodeDateTime obj "xd"
+    notionalPrincipal <- Decoders.getFieldOptional' decodeDecimal obj "nt"
+    premiumDiscountAtIED <- Decoders.getFieldOptional' decodeDecimal obj "pdied"
+    cycleAnchorDateOfPrincipalRedemption <- Decoders.getFieldOptional' decodeDateTime obj "pranx"
+    cycleOfPrincipalRedemption <- rmap (_ >>= decodeCycle) (obj .:? "prcl")
+    nextPrincipalRedemptionPayment <- Decoders.getFieldOptional' decodeDecimal obj "prnxt"
+    purchaseDate <- Decoders.getFieldOptional' decodeDateTime obj "prd"
+    priceAtPurchaseDate <- Decoders.getFieldOptional' decodeDecimal obj "pprd"
+    terminationDate <- Decoders.getFieldOptional' decodeDateTime obj "td"
+    priceAtTerminationDate <- Decoders.getFieldOptional' decodeDecimal obj "ptd"
+    quantity <- Decoders.getFieldOptional' decodeDecimal obj "qt"
+    currency <- obj .:? "cur"
+    currency2 <- obj .:? "cur2"
+    scalingIndexAtStatusDate <- Decoders.getFieldOptional' decodeDecimal obj "scsd"
+    cycleAnchorDateOfScalingIndex <- Decoders.getFieldOptional' decodeDateTime obj "scanx"
+    cycleOfScalingIndex <- rmap (_ >>= decodeCycle) (obj .:? "sccl")
+    scalingEffect <- obj .:? "scef"
+    scalingIndexAtContractDealDate <- Decoders.getFieldOptional' decodeDecimal obj "sccdd"
+    marketObjectCodeOfScalingIndex <- obj .:? "scmo"
+    notionalScalingMultiplier <- Decoders.getFieldOptional' decodeDecimal obj "scnt"
+    cycleOfOptionality <- rmap (_ >>= decodeCycle) (obj .:? "opcl")
+    cycleAnchorDateOfOptionality <- Decoders.getFieldOptional' decodeDateTime obj "opanx"
+    optionType <- obj .:? "optp"
+    optionStrike1 <- Decoders.getFieldOptional' decodeDecimal obj "ops1"
+    optionExerciseType <- obj .:? "opxt"
+    settlementPeriod <- rmap (_ >>= decodeCycle) (obj .:? "stp")
+    deliverySettlement <- obj .:? "ds"
+    exerciseAmount <- Decoders.getFieldOptional' decodeDecimal obj "xa"
+    futuresPrice <- Decoders.getFieldOptional' decodeDecimal obj "pfut"
+    penaltyRate <- Decoders.getFieldOptional' decodeDecimal obj "pyrt"
+    penaltyType <- obj .:? "pytp"
+    prepaymentEffect <- obj .:? "ppef"
+    cycleOfRateReset <- rmap (_ >>= decodeCycle) (obj .:? "rrcl")
+    cycleAnchorDateOfRateReset <- Decoders.getFieldOptional' decodeDateTime obj "rranx"
+    nextResetRate <- Decoders.getFieldOptional' decodeDecimal obj "rrnxt"
+    rateSpread <- Decoders.getFieldOptional' decodeDecimal obj "rrsp"
+    rateMultiplier <- Decoders.getFieldOptional' decodeDecimal obj "rrmlt"
+    periodFloor <- Decoders.getFieldOptional' decodeDecimal obj "rrpf"
+    periodCap <- Decoders.getFieldOptional' decodeDecimal obj "rrpc"
+    lifeCap <- Decoders.getFieldOptional' decodeDecimal obj "rrlc"
+    lifeFloor <- Decoders.getFieldOptional' decodeDecimal obj "rrlf"
+    marketObjectCodeOfRateReset <- obj .:? "rrmo"
+    cycleOfDividendPayment <- rmap (_ >>= decodeCycle) (obj .:? "dvcl")
+    cycleAnchorDateOfDividendPayment <- Decoders.getFieldOptional' decodeDateTime obj "dvanx"
+    nextDividendPaymentAmount <- Decoders.getFieldOptional' decodeDecimal obj "dvnxt"
+    pure $ ContractTerms
+      { contractId
+      , contractType
+      , contractRole
+      , settlementCurrency
+      , initialExchangeDate
+      , dayCountConvention
+      , scheduleConfig: { calendar, endOfMonthConvention, businessDayConvention }
+      , statusDate
+      , marketObjectCode
+      , contractPerformance
+      , creditEventTypeCovered
+      , coverageOfCreditEnhancement
+      , guaranteedExposure
+      , cycleOfFee
+      , cycleAnchorDateOfFee
+      , feeAccrued
+      , feeBasis
+      , feeRate
+      , cycleAnchorDateOfInterestPayment
+      , cycleOfInterestPayment
+      , accruedInterest
+      , capitalizationEndDate
+      , cycleAnchorDateOfInterestCalculationBase
+      , cycleOfInterestCalculationBase
+      , interestCalculationBase
+      , interestCalculationBaseAmount
+      , nominalInterestRate
+      , nominalInterestRate2
+      , interestScalingMultiplier
+      , maturityDate
+      , amortizationDate
+      , exerciseDate
+      , notionalPrincipal
+      , premiumDiscountAtIED
+      , cycleAnchorDateOfPrincipalRedemption
+      , cycleOfPrincipalRedemption
+      , nextPrincipalRedemptionPayment
+      , purchaseDate
+      , priceAtPurchaseDate
+      , terminationDate
+      , priceAtTerminationDate
+      , quantity
+      , currency
+      , currency2
+      , scalingIndexAtStatusDate
+      , cycleAnchorDateOfScalingIndex
+      , cycleOfScalingIndex
+      , scalingEffect
+      , scalingIndexAtContractDealDate
+      , marketObjectCodeOfScalingIndex
+      , notionalScalingMultiplier
+      , cycleOfOptionality
+      , cycleAnchorDateOfOptionality
+      , optionType
+      , optionStrike1
+      , optionExerciseType
+      , settlementPeriod
+      , deliverySettlement
+      , exerciseAmount
+      , futuresPrice
+      , penaltyRate
+      , penaltyType
+      , prepaymentEffect
+      , cycleOfRateReset
+      , cycleAnchorDateOfRateReset
+      , nextResetRate
+      , rateSpread
+      , rateMultiplier
+      , periodFloor
+      , periodCap
+      , lifeCap
+      , lifeFloor
+      , marketObjectCodeOfRateReset
+      , cycleOfDividendPayment
+      , cycleAnchorDateOfDividendPayment
+      , nextDividendPaymentAmount
+      , enableSettlement: false
+      }

--- a/test/Actus/Domain/ContractTerms.purs
+++ b/test/Actus/Domain/ContractTerms.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Actus.Domain (ContractTerms)
 import Control.Monad.Error.Class (throwError)
-import Data.Argonaut (Json, JsonDecodeError, decodeJson, jsonParser)
+import Data.Argonaut (Json, JsonDecodeError, decodeJson, encodeJson, jsonParser)
 import Data.Argonaut.Decode ((.:))
 import Data.Decimal (Decimal)
 import Data.Either (Either(..), either)
@@ -12,6 +12,7 @@ import Data.FoldableWithIndex (forWithIndex_)
 import Data.Traversable (traverse)
 import Effect.Exception (error)
 import Foreign.Object (Object)
+import Marlowe.Actus.Metadata (Metadata(..))
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff (readTextFile)
 import Test.Spec (Spec, describe, it, pending)
@@ -37,5 +38,30 @@ spec = do
           case terms of
             Left err -> fail (lamId <> ": " <> show err)
             Right _ -> pure unit
+
+      pending "feature complete"
+
+    describe "encode/decode metadata" do
+      it "actus-tests-lam.json" do
+        jsonStr <- readTextFile UTF8 "./test/Actus/Domain/actus-tests-lam.json"
+        json <- either (throwError <<< error) pure $ jsonParser jsonStr
+
+        (fixtures :: Object Json) <- either (throwError <<< error <<< show) pure do
+          decodeJson json >>= traverse \lamJson -> do
+            obj <- decodeJson lamJson
+            termsJson <- obj .: "terms"
+            pure $ termsJson
+
+        forWithIndex_ fixtures \lamId termsJson -> do
+          let
+            (terms :: Either JsonDecodeError (ContractTerms Decimal)) = decodeJson termsJson
+          case terms of
+            Left err -> fail (lamId <> ": " <> show err)
+            Right contract -> do
+              case (decodeJson <<< encodeJson $ Metadata contract) of
+                Right metadata ->
+                  if metadata == Metadata contract then pure unit
+                  else fail "Metadata not equal"
+                Left _ -> fail "Failed encoding/decoding Json"
 
       pending "feature complete"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -21,6 +21,7 @@ import Node.FS.Aff (readTextFile)
 import Node.Process (getEnv)
 import Test.Actus.Domain.ContractTerms as ContractTerms
 import Test.Marlowe.Actus as MarloweActus
+import Test.Marlowe.Actus.Metadata as Metadata
 import Test.Marlowe.Runtime.Web (_MARLOWE_WEB_SERVER_URL)
 import Test.Marlowe.Runtime.Web as Web
 import Test.Spec as Spec
@@ -40,6 +41,7 @@ main = do
     runSpec [ consoleReporter ] $ do
       Spec.parallel do
         ContractTerms.spec
+        Metadata.spec
         TestFramework.spec testsPAM
         TestFramework.spec testsLAM
         TestFramework.spec testsNAM

--- a/test/Marlowe/Actus/Metadata.purs
+++ b/test/Marlowe/Actus/Metadata.purs
@@ -1,10 +1,10 @@
-module Test.Actus.Domain.ContractTerms where
+module Test.Marlowe.Actus.Metadata where
 
 import Prelude
 
 import Actus.Domain (ContractTerms)
 import Control.Monad.Error.Class (throwError)
-import Data.Argonaut (Json, JsonDecodeError, decodeJson, jsonParser)
+import Data.Argonaut (Json, JsonDecodeError, decodeJson, encodeJson, jsonParser)
 import Data.Argonaut.Decode ((.:))
 import Data.Decimal (Decimal)
 import Data.Either (Either(..), either)
@@ -12,6 +12,7 @@ import Data.FoldableWithIndex (forWithIndex_)
 import Data.Traversable (traverse)
 import Effect.Exception (error)
 import Foreign.Object (Object)
+import Marlowe.Actus.Metadata (Metadata(..))
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff (readTextFile)
 import Test.Spec (Spec, describe, it, pending)
@@ -19,8 +20,7 @@ import Test.Spec.Assertions (fail)
 
 spec :: Spec Unit
 spec = do
-  describe "Actus.Domain.ContractTerms" do
-    describe "decodeJson" do
+    describe "encode/decode metadata" do
       it "actus-tests-lam.json" do
         jsonStr <- readTextFile UTF8 "./test/Actus/Domain/actus-tests-lam.json"
         json <- either (throwError <<< error) pure $ jsonParser jsonStr
@@ -36,6 +36,11 @@ spec = do
             (terms :: Either JsonDecodeError (ContractTerms Decimal)) = decodeJson termsJson
           case terms of
             Left err -> fail (lamId <> ": " <> show err)
-            Right _ -> pure unit
+            Right contract -> do
+              case (decodeJson <<< encodeJson $ Metadata contract) of
+                Right metadata ->
+                  if metadata == Metadata contract then pure unit
+                  else fail "Metadata not equal"
+                Left _ -> fail "Failed encoding/decoding Json"
 
       pending "feature complete"


### PR DESCRIPTION
Providing alternative (smaller) JSON encoding/decoding to put into the `metadata` of the transaction.